### PR TITLE
Fine tune start of sampling in PIO

### DIFF
--- a/firmware/pico/application/adsbee.cc
+++ b/firmware/pico/application/adsbee.cc
@@ -161,8 +161,9 @@ bool ADSBee::Init() {
         pio_sm_exec(config_.preamble_detector_pio, preamble_detector_sm_[sm_index], pio_encode_in(pio_null, 4));
         // in x 3       ; ISR = 0b00000000000000000000001?10000101
         pio_sm_exec(config_.preamble_detector_pio, preamble_detector_sm_[sm_index], pio_encode_in(pio_x, 3));
-        // in null 5    ; ISR = 0b000000000000000001?1000010100000
-        pio_sm_exec(config_.preamble_detector_pio, preamble_detector_sm_[sm_index], pio_encode_in(pio_null, 5));
+        // in null 4    ; ISR = 0b0000000000000000001?100001010000
+        // Note: this is shorter than the real tail but we need extra time for the demodulator to start up.
+        pio_sm_exec(config_.preamble_detector_pio, preamble_detector_sm_[sm_index], pio_encode_in(pio_null, 4));
         // mov x null   ; Clear scratch x.
         pio_sm_exec(config_.preamble_detector_pio, preamble_detector_sm_[sm_index], pio_encode_mov(pio_x, pio_null));
 

--- a/firmware/pico/application/pio/capture.pio
+++ b/firmware/pico/application/pio/capture.pio
@@ -57,8 +57,8 @@ void irq_wrapper_program_init(
 .wrap_target
 public waiting_for_first_edge:
     irq set 6                       ; -4 | Spam resetting the high power preamble detector.
-    mov osr isr                     ; -3 | OSR = 0b00000000000000000101000010100000
-    out null 17                     ; -2 | OSR = 0b101000010100000
+    mov osr isr                     ; -3 | OSR = 0b00000000000000000010100001010000
+    out null 18                     ; -2 | OSR = 0b10100001010000
     mov x null                      ; -1 | Clear out x from last sampling adventure.
 ; Grab a new bit every 24 cycles.
 ;   6 cycles: Get bit.
@@ -258,13 +258,13 @@ sample_return:
     jmp end_of_1  ; 23 | End of 1
 
 public initial_entry:
-    wait 1 pin demod_in_pin_index side 0   ; -16 | Wait to enter DEMOD interval.
+    wait 1 pin demod_in_pin_index [6] side 0   ; -16 | Wait to enter DEMOD interval.
     ; Preamble ends LO, so imitate the end of a 1 with its HI->LO transition.
-    jmp initial_entry_cut_in [1]            ; -15:-14 | wait adjusted here
+    jmp initial_entry_cut_in [6]            ; -15:-14 | wait adjusted here
 
 public high_power_initial_entry:
-    wait 1 pin high_power_demod_in_pin_index side 0
-    jmp initial_entry_cut_in [1]
+    wait 1 pin high_power_demod_in_pin_index [6] side 0
+    jmp initial_entry_cut_in [6]
 
 start_of_1:
     wait 0 pin pulses_pin_index ; 0 | Wait for the 1->0 transition - at this point we are 0.5 into the bit.


### PR DESCRIPTION
* Shortens the preamble by 1us and adds necessary delays to shift the first oversampling period to the center of the first bit-time.

Slight increase in maximum range and packets per second. Fine-tuned decoder on left, original decoder on right.
![image](https://github.com/user-attachments/assets/29c938c6-0caf-4875-9e37-434f2d41d6c9)
