### PR TITLE
Fix crash when settings are overwritten

### DIFF
--- a/firmware/common/settings/settings.hh
+++ b/firmware/common/settings/settings.hh
@@ -276,11 +276,11 @@ class SettingsManager {
         char ota_keys[kNumOTAKeys][kOTAKeyMaxLen + 1];
 
         enum ADSBeePartNumber : uint32_t {
-            kPNADSBee1090 = 010240002,            // ADSBee 1090
-            kPNADSBee1090U = 010250002,           // ADSBee 1090U
-            kPNADSBeem1090 = 010250007,           // ADSBee m1090
-            kPNADSBeem1090EvalBoard = 010250013,  // ADSBee m1090 Eval Board
-            kPNGS3MPoE = 040250001                // GS3M PoE
+            kPNADSBee1090 = 10240002,            // ADSBee 1090
+            kPNADSBee1090U = 10250002,           // ADSBee 1090U
+            kPNADSBeem1090 = 10250007,           // ADSBee m1090
+            kPNADSBeem1090EvalBoard = 10250013,  // ADSBee m1090 Eval Board
+            kPNGS3MPoE = 40250001                // GS3M PoE
         };
 
         /**

--- a/firmware/pico/application/comms/at/comms_at.cc
+++ b/firmware/pico/application/comms/at/comms_at.cc
@@ -904,6 +904,7 @@ CPP_AT_CALLBACK(CommsManager::ATSettingsCallback) {
                     }
                 } else if (args[0].compare("RESET") == 0) {
                     settings_manager.ResetToDefaults();
+                    settings_manager.Apply();
                 } else {
                     CPP_AT_ERROR("Invalid argument %s.", args[0].data());
                 }

--- a/firmware/pico/application/settings.cc
+++ b/firmware/pico/application/settings.cc
@@ -160,7 +160,6 @@ void SettingsManager::ResetToDefaults() {
                 break;
         }
     }
-    Apply();
 }
 
 bool SettingsManager::SetDeviceInfo(const DeviceInfo& device_info) {


### PR DESCRIPTION
* Moved settings Apply() out of ResetToDefaults() so that we don't end up with issues from trying to apply new settings to the CC1312 and ESP32 during a settings version update before they have been initialized.