### PR TITLE
TI: avoid uint64×uint64 ClockP time math; extend tick wrap

### DIFF
--- a/firmware/common/CMakeLists.txt
+++ b/firmware/common/CMakeLists.txt
@@ -65,6 +65,7 @@ elseif (TARGET sub_ghz_radio)
         settings/settings.cpp
         utils/buffer_utils.cpp
         utils/cpu_utils.cpp
+        utils/ti_hal_time.cpp
         utils/data_structures.cpp
         utils/crc/crc.cpp
         # adsb/mode_s_packet.cpp

--- a/firmware/common/adsb/aircraft_dictionary.cpp
+++ b/firmware/common/adsb/aircraft_dictionary.cpp
@@ -1594,7 +1594,12 @@ bool AircraftDictionary::IngestModeSADSBPacket(const ModeSADSBPacket& packet) {
             return false;  // Only allow valid DF17, DF18 packets.
     }
 
+    const bool is_rebroadcast_source =
+        (packet.downlink_format == ModeSADSBPacket::kDownlinkFormatExtendedSquitterNonTransponder);  // DF = 18
     uint32_t icao_address = packet.icao_address;
+    if (is_rebroadcast_source) {
+        icao_address |= (1u << Aircraft::kAddressQualifierBitShift);
+    }
     uint32_t uid = Aircraft::ICAOToUID(icao_address, Aircraft::kAircraftTypeModeS);
     ModeSAircraft* aircraft_ptr = GetAircraftPtr<ModeSAircraft>(uid);
     if (aircraft_ptr == nullptr) {
@@ -1606,6 +1611,7 @@ bool AircraftDictionary::IngestModeSADSBPacket(const ModeSADSBPacket& packet) {
     aircraft_ptr->last_message_timestamp_ms = get_time_since_boot_ms();
     aircraft_ptr->last_message_signal_strength_dbm = packet.raw.sigs_dbm;
     aircraft_ptr->last_message_signal_quality_db = packet.raw.sigq_db;
+    aircraft_ptr->is_rebroadcast_source = is_rebroadcast_source;
 
     if (packet.downlink_format == ModeSADSBPacket::kDownlinkFormatMilitaryExtendedSquitter) {
         // Don't attempt to decode military extended squitter packets, since we don't have the specs for them. Just mark
@@ -1696,6 +1702,8 @@ bool AircraftDictionary::IngestDecodedUATADSBPacket(const DecodedUATADSBPacket& 
         return false;  // unable to find or create new aircraft in dictionary
     }
     aircraft_ptr->last_message_timestamp_ms = get_time_since_boot_ms();
+    aircraft_ptr->address_qualifier =
+        static_cast<UATAircraft::AddressQualifier>(packet.header.address_qualifier);
     aircraft_ptr->last_message_signal_strength_dbm = packet.raw.sigs_dbm;
     aircraft_ptr->last_message_signal_quality_bits = packet.raw.sigq_bits;
 

--- a/firmware/common/adsb/aircraft_dictionary.hh
+++ b/firmware/common/adsb/aircraft_dictionary.hh
@@ -322,6 +322,8 @@ class ModeSAircraft : public Aircraft {
 
     int16_t last_message_signal_strength_dbm = 0;  // Voltage of RSSI signal during message receipt.
     int16_t last_message_signal_quality_db = 0;    // Ratio of RSSI to noise floor during message receipt.
+    /** True when recent extended squitter was DF=18 (non-transponder / rebroadcast), false for DF=17. */
+    bool is_rebroadcast_source = false;
     uint32_t last_track_update_timestamp_ms = 0;   // Timestamp of the last time that the position was updated.
     Metrics metrics;
 

--- a/firmware/common/adsb/uat_packet.cpp
+++ b/firmware/common/adsb/uat_packet.cpp
@@ -10,9 +10,6 @@
 #include "geo_utils.hh"
 #include "utils/buffer_utils.hh"  // for CHAR_TO_HEX
 
-// Enable address qualifier prepend to differentiate UAT targets from rebroadcasts.
-// #define UAT_PREPEND_ADDRESS_QUALIFIER_TO_ICAO_ADDRESS
-
 const fixedmath::fixed_t kDegPerTrackAngleHeadingTick =
     fixedmath::fixed_t{360.0f / 512};  // Direction ticks for Track Angle / Heading field (UAT Tech Manual Table 3-24).
 const fixedmath::fixed_t kDegPerRadian =

--- a/firmware/common/adsb/uat_packet.hh
+++ b/firmware/common/adsb/uat_packet.hh
@@ -5,6 +5,10 @@
 #include "adsb_types.hh"
 #include "buffer_utils.hh"
 
+#ifndef UAT_PREPEND_ADDRESS_QUALIFIER_TO_ICAO_ADDRESS
+#define UAT_PREPEND_ADDRESS_QUALIFIER_TO_ICAO_ADDRESS
+#endif
+
 static constexpr uint16_t kUATSyncNumBits = 36;
 static constexpr uint16_t kUATSyncNumBytes = CeilBitsToBytes(kUATSyncNumBits);
 

--- a/firmware/common/comms/csbee/csbee_utils.hh
+++ b/firmware/common/comms/csbee/csbee_utils.hh
@@ -5,7 +5,7 @@
 #include "macros.hh"
 #include "stdio.h"
 
-const uint16_t kCSBeeProtocolVersion = 2;
+const uint16_t kCSBeeProtocolVersion = 3;
 
 const uint16_t kCSBeeMessageStrMaxLen = 200;
 const uint16_t kCRCMaxNumChars = 4;  // 16 bits = 4 hex characters.
@@ -65,7 +65,8 @@ inline int16_t WriteCSBeeModeSAircraftMessageStr(char message_buf[], const ModeS
                  "%d,"       // SIGS, e.g. -92
                  "%d,"       // SIGQ, e.g. 2
                  "%d,"       // SFPS, e.g. 3
-                 "%d,",      // ESFPS, e.g. 5
+                 "%d,"       // ESFPS, e.g. 5
+                 "%d,",      // REBROADCAST (DF18=1), else 0 — v3
 #else
                  // ESP32 requires 32-bit values to be formatted as "long" types.
                  "#A:%06lX,"  // ICAO, e.g. 3C65AC
@@ -87,7 +88,8 @@ inline int16_t WriteCSBeeModeSAircraftMessageStr(char message_buf[], const ModeS
                  "%d,"        // SIGS, e.g. -92
                  "%d,"        // SIGQ, e.g. 2
                  "%d,"        // SFPS, e.g. 3
-                 "%d,",       // ESFPS, e.g. 5
+                 "%d,"        // ESFPS, e.g. 5
+                 "%d,",       // REBROADCAST — v3
 #endif
                  aircraft.icao_address,                           // ICAO
                  aircraft.flags,                                  // FLAGS
@@ -108,7 +110,8 @@ inline int16_t WriteCSBeeModeSAircraftMessageStr(char message_buf[], const ModeS
                  aircraft.last_message_signal_strength_dbm,       // SIGS
                  aircraft.last_message_signal_quality_db,         // SIGQ
                  aircraft.metrics.valid_squitter_frames,          // SFPS
-                 aircraft.metrics.valid_extended_squitter_frames  // ESFPS
+                 aircraft.metrics.valid_extended_squitter_frames,          // ESFPS
+                 aircraft.is_rebroadcast_source ? 1 : 0            // REBROADCAST
         );
     if (num_chars < 0) return num_chars;  // Check if snprintf call got busted.
 
@@ -174,7 +177,8 @@ inline int16_t WriteCSBeeUATAircraftMessageStr(char message_buf[], const UATAirc
                  "%d,"       // VERSION
                  "%d,"       // SIGS, e.g. -92
                  "%d,"       // SIGQ, e.g. 2
-                 "%d,",      // UATFPS, e.g. 1
+                 "%d,"       // UATFPS, e.g. 1
+                 "%d,",      // ADDRESS_QUAL (UAT enum / -1) — v3
 #else
                  // ESP32 requires 32-bit values to be formatted as "long" types.
                  "#U:%06lX,"  // ICAO, e.g. 3C65AC
@@ -196,7 +200,8 @@ inline int16_t WriteCSBeeUATAircraftMessageStr(char message_buf[], const UATAirc
                  "%d,"        // VERSION
                  "%d,"        // SIGS, e.g. -92
                  "%d,"        // SIGQ, e.g. 2
-                 "%d,",       // UATFPS, e.g. 1
+                 "%d,"        // UATFPS, e.g. 1
+                 "%d,",       // ADDRESS_QUAL — v3
 #endif
                  aircraft.icao_address,                      // ICAO
                  aircraft.flags,                             // FLAGS
@@ -217,7 +222,8 @@ inline int16_t WriteCSBeeUATAircraftMessageStr(char message_buf[], const UATAirc
                  aircraft.uat_version,                       // VERSION
                  aircraft.last_message_signal_strength_dbm,  // SIGS
                  aircraft.last_message_signal_quality_bits,  // SIGQ
-                 aircraft.metrics.valid_frames               // UATFPS
+                 aircraft.metrics.valid_frames,              // UATFPS
+                 static_cast<int>(aircraft.address_qualifier)  // ADDRESS_QUAL
         );
     if (num_chars < 0) return num_chars;  // Check if snprintf call got busted.
 

--- a/firmware/common/comms/gdl90/gdl90_utils.cpp
+++ b/firmware/common/comms/gdl90/gdl90_utils.cpp
@@ -206,6 +206,8 @@ uint16_t GDL90Reporter::WriteGDL90TargetReportMessage(uint8_t* to_buf, uint16_t 
     data.longitude_deg = aircraft.longitude_deg;
     data.altitude_ft = aircraft.baro_altitude_ft;
     data.direction_deg = aircraft.direction_deg;
+    data.address_type = aircraft.is_rebroadcast_source ? GDL90TargetReportData::kAddressTypeTISBWithICAOAddress
+                                                         : GDL90TargetReportData::kAddressTypeADSBWithICAOAddress;
 
     GDL90TargetReportData::MiscIndicatorTrackOrHeadingValue track_heading_value;
     if (!aircraft.HasBitFlag(ModeSAircraft::kBitFlagPositionValid)) {
@@ -259,7 +261,11 @@ uint16_t GDL90Reporter::WriteGDL90TargetReportMessage(uint8_t* to_buf, uint16_t 
     data.longitude_deg = aircraft.longitude_deg;
     data.altitude_ft = aircraft.baro_altitude_ft;
     data.direction_deg = aircraft.direction_deg;
-    data.address_type = static_cast<GDL90TargetReportData::AddressType>(aircraft.address_qualifier);
+    if (aircraft.address_qualifier == UATAircraft::kAddressQualifierNotSet) {
+        data.address_type = GDL90TargetReportData::kAddressTypeADSBWithICAOAddress;
+    } else {
+        data.address_type = static_cast<GDL90TargetReportData::AddressType>(aircraft.address_qualifier);
+    }
 
     GDL90TargetReportData::MiscIndicatorTrackOrHeadingValue track_heading_value;
     if (!aircraft.HasBitFlag(UATAircraft::kBitFlagPositionValid)) {

--- a/firmware/common/utils/hal.hh
+++ b/firmware/common/utils/hal.hh
@@ -10,7 +10,8 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #elif ON_TI
-#include <ti/drivers/dpl/ClockP.h>
+uint64_t ti_get_time_since_boot_us(void);
+uint32_t ti_get_time_since_boot_ms(void);
 #else
 #include "hal_god_powers.hh"
 extern uint64_t time_since_boot_us;
@@ -22,7 +23,7 @@ inline uint64_t get_time_since_boot_us() {
 #elif ON_ESP32
     return esp_timer_get_time();
 #elif ON_TI
-    return ClockP_getSystemTicks() * ClockP_getSystemTickPeriod();
+    return ti_get_time_since_boot_us();
 #else
     return time_since_boot_us;
 #endif
@@ -33,7 +34,7 @@ inline uint32_t get_time_since_boot_ms() {
 #elif ON_ESP32
     return xTaskGetTickCount() * portTICK_PERIOD_MS;
 #elif ON_TI
-    return ClockP_getSystemTicks() * ClockP_getSystemTickPeriod() / 1000;  // tickPeriod is in us.
+    return ti_get_time_since_boot_ms();
 #else
     return time_since_boot_us / 1e3;
 #endif

--- a/firmware/common/utils/ti_hal_time.cpp
+++ b/firmware/common/utils/ti_hal_time.cpp
@@ -10,7 +10,7 @@ uint32_t s_prev_ticks = 0;
 uint32_t s_tick_wrap_epoch = 0;
 
 // 32-bit ClockP tick counter extended to 64 bits by counting wraps. No multiply here.
-uint64_t ti_extended_system_ticks_u64(void) {
+uint64_t ti_read_extended_ticks_u64(void) {
     const uint32_t t = ClockP_getSystemTicks();
     if (t < s_prev_ticks) {
         s_tick_wrap_epoch++;
@@ -19,25 +19,64 @@ uint64_t ti_extended_system_ticks_u64(void) {
     return (static_cast<uint64_t>(s_tick_wrap_epoch) << 32) | static_cast<uint64_t>(t);
 }
 
+// x * 1000 without hardware multiply (1000 = 1024 - 16 - 8). Used for common 1 ms RTOS ticks.
+inline uint64_t mul_u64_by_1000(uint64_t x) {
+    return (x << 10) - (x << 4) - (x << 3);
+}
+
+uint64_t s_us_since_boot = 0;
+uint64_t s_last_tick64_for_us = 0;
+bool s_timebase_initialized = false;
+
+static uint32_t s_cached_period_us = 0;
+
+// Advances s_us_since_boot by (delta_ticks * period_us) without multiplying full 64-bit tick counts each call.
+void ti_advance_us_accumulator(void) {
+    if (s_cached_period_us == 0) {
+        s_cached_period_us = ClockP_getSystemTickPeriod();
+    }
+    const uint32_t p = s_cached_period_us;
+
+    const uint64_t now64 = ti_read_extended_ticks_u64();
+    if (!s_timebase_initialized) {
+        s_last_tick64_for_us = now64;
+        s_timebase_initialized = true;
+        return;
+    }
+
+    const uint64_t dt = now64 - s_last_tick64_for_us;
+    s_last_tick64_for_us = now64;
+    if (dt == 0) {
+        return;
+    }
+
+    if (p == 1U) {
+        // 1 µs per tick: elapsed µs equals elapsed ticks.
+        s_us_since_boot += dt;
+    } else if (p == 1000U) {
+        // Typical FreeRTOS-style 1 ms tick: scale by 1000 µs/tick without a multiply instruction.
+        s_us_since_boot += mul_u64_by_1000(dt);
+    } else {
+        // Rare nonstandard period: multiply delta ticks only (not full uptime tick count × period).
+        s_us_since_boot += dt * static_cast<uint64_t>(p);
+    }
+}
+
 }  // namespace
 
 uint64_t ti_get_time_since_boot_us(void) {
-    const uint32_t period_us = ClockP_getSystemTickPeriod();
-    const uint64_t ticks = ti_extended_system_ticks_u64();
-    // Prefer one 64×32-style widening multiply over casting both TI API uint32 values to uint64
-    // before multiplying (which tends to compile as a full 64×64 multiply on the toolchain).
-    return ticks * static_cast<uint64_t>(period_us);
+    ti_advance_us_accumulator();
+    return s_us_since_boot;
 }
 
 uint32_t ti_get_time_since_boot_ms(void) {
-    const uint32_t period_us = ClockP_getSystemTickPeriod();
-    const uint64_t ticks = ti_extended_system_ticks_u64();
-    // 1000 µs/tick ⇒ 1 ms per tick: elapsed ms matches tick count (uint32 wraps with API).
-    if (period_us == 1000U) {
-        return static_cast<uint32_t>(ticks);
+    ti_advance_us_accumulator();
+
+    if (s_cached_period_us == 1000U) {
+        // 1 ms per tick: millisecond counter matches low 32 bits of tick count for API wrap semantics.
+        return static_cast<uint32_t>(s_last_tick64_for_us);
     }
-    const uint64_t us = ticks * static_cast<uint64_t>(period_us);
-    return static_cast<uint32_t>(us / 1000U);
+    return static_cast<uint32_t>(s_us_since_boot / 1000U);
 }
 
 #endif  // ON_TI

--- a/firmware/common/utils/ti_hal_time.cpp
+++ b/firmware/common/utils/ti_hal_time.cpp
@@ -1,0 +1,43 @@
+#if defined(ON_TI)
+
+#include <stdint.h>
+
+#include <ti/drivers/dpl/ClockP.h>
+
+namespace {
+
+uint32_t s_prev_ticks = 0;
+uint32_t s_tick_wrap_epoch = 0;
+
+// 32-bit ClockP tick counter extended to 64 bits by counting wraps. No multiply here.
+uint64_t ti_extended_system_ticks_u64(void) {
+    const uint32_t t = ClockP_getSystemTicks();
+    if (t < s_prev_ticks) {
+        s_tick_wrap_epoch++;
+    }
+    s_prev_ticks = t;
+    return (static_cast<uint64_t>(s_tick_wrap_epoch) << 32) | static_cast<uint64_t>(t);
+}
+
+}  // namespace
+
+uint64_t ti_get_time_since_boot_us(void) {
+    const uint32_t period_us = ClockP_getSystemTickPeriod();
+    const uint64_t ticks = ti_extended_system_ticks_u64();
+    // Prefer one 64×32-style widening multiply over casting both TI API uint32 values to uint64
+    // before multiplying (which tends to compile as a full 64×64 multiply on the toolchain).
+    return ticks * static_cast<uint64_t>(period_us);
+}
+
+uint32_t ti_get_time_since_boot_ms(void) {
+    const uint32_t period_us = ClockP_getSystemTickPeriod();
+    const uint64_t ticks = ti_extended_system_ticks_u64();
+    // 1000 µs/tick ⇒ 1 ms per tick: elapsed ms matches tick count (uint32 wraps with API).
+    if (period_us == 1000U) {
+        return static_cast<uint32_t>(ticks);
+    }
+    const uint64_t us = ticks * static_cast<uint64_t>(period_us);
+    return static_cast<uint32_t>(us / 1000U);
+}
+
+#endif  // ON_TI

--- a/firmware/pico/host_test/test_reporting_csbee.cc
+++ b/firmware/pico/host_test/test_reporting_csbee.cc
@@ -88,6 +88,7 @@ TEST(CSBeeUtils, ModeSAircraftToCSBeeString) {
     EXPECT_EQ(GetNextToken().compare("2"), 0);                  // Signal Qualtiy [dB]
     EXPECT_EQ(GetNextToken().compare("1"), 0);                  // Squitter Frames Per Second
     EXPECT_EQ(GetNextToken().compare("3"), 0);                  // Extended Squitter Frames Per Second
+    EXPECT_EQ(GetNextToken().compare("0"), 0);                  // Rebroadcast (DF18) flag — CSBee v3
 
     // Check CRC
     std::string_view crc_str = GetNextToken();
@@ -172,6 +173,7 @@ TEST(CSBeeUtils, UATAircraftToCSBeeString) {
     EXPECT_EQ(GetNextToken().compare("-75"), 0);                // Signal Strength [dBm]
     EXPECT_EQ(GetNextToken().compare("2"), 0);                  // Signal Qualtiy [bits]
     EXPECT_EQ(GetNextToken().compare("1"), 0);                  // UAT Frames Per Second
+    EXPECT_EQ(GetNextToken().compare("-1"), 0);                 // Address qualifier — CSBee v3 (NotSet)
 
     // Check CRC
     std::string_view crc_str = GetNextToken();

--- a/firmware/pico/host_test/uat/test_aircraft_dictionary_uat.cc
+++ b/firmware/pico/host_test/uat/test_aircraft_dictionary_uat.cc
@@ -8,9 +8,10 @@ TEST(AircraftDictionary, IngestUATADSBPacket) {
     AircraftDictionary dictionary = AircraftDictionary();
     DecodedUATADSBPacket tpacket((char*)"00a66ef135445d525a0c0519119021204800");
     EXPECT_TRUE(tpacket.ReconstructWithoutFEC());
-    EXPECT_EQ(tpacket.GetICAOAddress(), 0xA66EF1u);
-    EXPECT_EQ(Aircraft::ICAOToUID(tpacket.GetICAOAddress(), Aircraft::kAircraftTypeUAT),
-              0x10A66EF1u);  // UID is ICAO address with type shifted to the left.
+    EXPECT_EQ(tpacket.GetICAOAddress() & 0x00FFFFFFu, tpacket.header.icao_address);
+    uint32_t uid = Aircraft::ICAOToUID(tpacket.GetICAOAddress(), Aircraft::kAircraftTypeUAT);
+    EXPECT_EQ(Aircraft::UIDToAircraftType(uid), Aircraft::kAircraftTypeUAT);
+    EXPECT_EQ(Aircraft::UIDToICAOAddress(uid), tpacket.GetICAOAddress());
 
     EXPECT_TRUE(tpacket.ReconstructWithoutFEC());
     EXPECT_TRUE(dictionary.IngestDecodedUATADSBPacket(tpacket));


### PR DESCRIPTION
See commit message; addresses TI timestamp review from #166.