### PR TITLE
gdl traffic and heartbeat fixes

### DIFF
--- a/firmware/adsbee_1090/build.sh
+++ b/firmware/adsbee_1090/build.sh
@@ -61,7 +61,7 @@ build_pico() {
 build_test() {
     echo "=== Building and running host tests ==="
     docker compose run --rm pico-docker bash -c "
-        cd /firmware/adsbee_1090/modules/googletest &&
+        cd /firmware/modules/googletest &&
         mkdir -p build && cd build &&
         cmake -DBUILD_SHARED_LIBS=ON .. &&
         make -j $jobs &&

--- a/firmware/adsbee_1090/esp/main/server/adsbee_server.cpp
+++ b/firmware/adsbee_1090/esp/main/server/adsbee_server.cpp
@@ -276,7 +276,8 @@ bool ADSBeeServer::ReportGDL90() {
     // Heartbeat Message
     message.len = gdl90.WriteGDL90HeartbeatMessage(message.data, CommsManager::NetworkMessage::kMaxLenBytes,
                                                    get_time_since_boot_ms() / 1000,
-                                                   aircraft_dictionary.metrics.valid_extended_squitter_frames);
+                                                   aircraft_dictionary.metrics.valid_extended_squitter_frames, 
+                                                   aircraft_dictionary.metrics.valid_uat_uplink_frames);
     comms_manager.WiFiAccessPointSendMessageToAllStations(message);
 
     // Ownship Report

--- a/firmware/adsbee_1090/pico/host_test/test_reporting_gdl90.cc
+++ b/firmware/adsbee_1090/pico/host_test/test_reporting_gdl90.cc
@@ -108,9 +108,11 @@ TEST(GDL90Utils, HeartBeatMessage) {
     gdl90.utc_timing_is_valid = true;
     // Timestamp must have MS bit = 0b0.
     uint32_t timestamp = (0b0 << 16) | 0xD0DB;  // Set timestamp to match sample message.
-    uint16_t message_counts = 0x0208;
+    uint16_t modeS_message_counts = 2;
+    uint16_t UAT_message_counts = 1;
     ASSERT_EQ(
-        11, gdl90.WriteGDL90HeartbeatMessage(buf, GDL90Reporter::kGDL90MessageMaxLenBytes, timestamp, message_counts));
+        11, gdl90.WriteGDL90HeartbeatMessage(buf, GDL90Reporter::kGDL90MessageMaxLenBytes, timestamp, 
+                                             modeS_message_counts, UAT_message_counts));
     EXPECT_EQ(buf[0], 0x7E);
     EXPECT_EQ(buf[1], 0x00);
     EXPECT_EQ(buf[2], 0x81);

--- a/firmware/common/comms/comms_reporting.cpp
+++ b/firmware/common/comms/comms_reporting.cpp
@@ -342,7 +342,8 @@ bool CommsManager::ReportGDL90(ReportSink* sinks, uint16_t num_sinks) {
 
     // Heartbeat Message
     msg_len = gdl90.WriteGDL90HeartbeatMessage(buf, sizeof(buf), get_time_since_boot_ms() / 1000,
-                                               aircraft_dictionary.metrics.valid_extended_squitter_frames);
+                                                aircraft_dictionary.metrics.valid_extended_squitter_frames, 
+                                                aircraft_dictionary.metrics.valid_uat_uplink_frames);
 
     for (uint16_t i = 0; i < num_sinks; i++) {
         ret &= SendBuf(sinks[i], (char*)buf, msg_len);

--- a/firmware/common/comms/gdl90/gdl90_utils.cpp
+++ b/firmware/common/comms/gdl90/gdl90_utils.cpp
@@ -68,7 +68,8 @@ uint16_t GDL90Reporter::WriteBufferWithGDL90Escapes(uint8_t* to_buf, uint16_t to
 }
 
 uint16_t GDL90Reporter::WriteGDL90HeartbeatMessage(uint8_t* to_buf, uint16_t to_buf_num_bytes,
-                                                   uint32_t timestamp_sec_since_0000z, uint16_t message_counts) {
+                                                   uint32_t timestamp_sec_since_0000z, 
+                                                   uint16_t modeS_message_counts, uint16_t uat_message_counts) {
     const uint16_t kMessageBufLenBytes = 7;
     uint8_t message_buf[kMessageBufLenBytes];
     // 1: Message ID
@@ -86,9 +87,13 @@ uint16_t GDL90Reporter::WriteGDL90HeartbeatMessage(uint8_t* to_buf, uint16_t to_
     message_buf[3] = timestamp_sec_since_0000z & 0xFF;         // Timestamp LSB.
     message_buf[4] = (timestamp_sec_since_0000z >> 8) & 0xFF;  // Timestamp MSB (missing MS bit).
     // 6-7: Message Counts
-    message_counts = MIN(1023, message_counts);
-    message_buf[5] = message_counts & 0xFF;
-    message_buf[6] = message_counts >> 8;
+    modeS_message_counts = MIN(1023, modeS_message_counts);
+    uat_message_counts = std::min<uint8_t>(31, uat_message_counts);
+    message_buf[5] = static_cast<uint8_t>(((uat_message_counts & 0x1F) << 3) |          // bits 7..3
+                                            ((modeS_message_counts >> 8) & 0x03)        // bits 1..0
+                                            );                                          // bit 2 left as 0
+    message_buf[6] = static_cast<uint8_t>(modeS_message_counts & 0xFF);
+
     return WriteGDL90Message(to_buf, to_buf_num_bytes, message_buf, kMessageBufLenBytes);
 }
 
@@ -167,23 +172,38 @@ uint16_t GDL90Reporter::WriteGDL90TargetReportMessage(uint8_t* to_buf, uint16_t 
     message_buf[8] = (longitude_frac >> 16) & 0xFF;
     message_buf[9] = (longitude_frac >> 8) & 0xFF;
     message_buf[10] = longitude_frac & 0xFF;
-    // ddd: Altitude as a 12-bit offset integer. Resolution = 25 feet.
-    int16_t altitude_frac = static_cast<int16_t>(data.altitude_ft / 25) & 0x0FFF;
-    message_buf[11] = altitude_frac >> 4;  // dd: Altitude MS Byte.
 
-    message_buf[12] = (altitude_frac & 0xF) |        // d: Altitude LS nibble.
-                      (data.misc_indicators & 0xF);  // m: Miscellaneous indicators.
+    // ddd: Altitude as a 12-bit offset integer. Resolution = 25 feet.
+    uint16_t altitude_frac = static_cast<uint16_t>((data.altitude_ft + 1000) / 25);
+    message_buf[11] = (altitude_frac >> 4) & 0xFF;      // dd: Altitude MS Byte.
+    message_buf[12] = ((altitude_frac & 0xF) << 4) |    // d: Altitude LS nibble.
+                      (data.misc_indicators & 0xF);     // m: Miscellaneous indicators.
+
     message_buf[13] =
         ((data.navigation_integrity_category & 0xF) << 4)      // i: Navigation Integrity Category (NIC).
         | (data.navigation_accuracy_category_position & 0xF);  // a: Navigation Accuracy Category for Position (NACp).
+
     // hhh: Horizontal Velocity. Resolution = 1kt.
-    uint32_t speed_kts = static_cast<uint32_t>(data.speed_kts) & 0x00000FFF;
+    uint16_t speed_kts = static_cast<uint16_t>(data.speed_kts);
+    if (speed_kts >= 0xFFF) {
+        speed_kts = 0xFFE;   // 0xFFF = invalid / unavailable
+    }
+
     // vvv: Vertical Velocity. Signed Integer in units of 64fpm.
-    int32_t vertical_rate_fpm = (data.vertical_rate_fpm / 64) & 0x000000FFF;
-    message_buf[14] = speed_kts >> 4;              // hh: MSB of Horizontal Velocity.
-    message_buf[15] = (speed_kts & 0xF)            // h: LS nibble of Horizontal Velocity.
-                      | (vertical_rate_fpm >> 8);  // v: MS nibble of Vertical Rate.
-    message_buf[16] = vertical_rate_fpm & 0xFF;    // vv: LSB of Vertical Rate.
+    int32_t vertical_rate_64fpm = static_cast<int32_t>(data.vertical_rate_fpm) / 64;
+    if (vertical_rate_64fpm > 0x1FE)    {
+        vertical_rate_64fpm = 0x1FE;          // > +32,576 fpm climb
+    }   else if (vertical_rate_64fpm < -0x1FE)  {
+        vertical_rate_64fpm = -0x1FE;         // > 32,576 fpm descend
+    }
+
+    uint16_t vertical_rate_encoded = static_cast<uint16_t>(vertical_rate_64fpm) & 0x0FFF;
+
+    message_buf[14] = (speed_kts >> 4) & 0xFF;                  // hh: MSB of Horizontal Velocity.
+    message_buf[15] = ((speed_kts & 0xF) << 4)                  // h: LS nibble of Horizontal Velocity.
+                      | ((vertical_rate_encoded >> 8) & 0x0F);  // v: MS nibble of Vertical Rate.
+    message_buf[16] = vertical_rate_encoded & 0xFF;             // vv: LSB of Vertical Rate.
+
     // tt: Track / Heading. 8-bit angular weighted binary. Resolution = 360/256 degrees. 0 = North,
     // 128 = South. Indicate track or heading using misc bit field.
     message_buf[17] = static_cast<uint32_t>(data.direction_deg * kHeadingTrackDegTo8BitFrac) & 0x000000FF;
@@ -241,7 +261,7 @@ uint16_t GDL90Reporter::WriteGDL90TargetReportMessage(uint8_t* to_buf, uint16_t 
                                  ? aircraft.baro_vertical_rate_fpm
                                  : aircraft.gnss_vertical_rate_fpm;
     data.direction_deg = aircraft.direction_deg;
-    data.emitter_category = aircraft.emitter_category_raw;
+    data.emitter_category = static_cast<uint8_t>(aircraft.emitter_category);
     // GDL90 does not provide space for an EOS character, since it only provides 8 Bytes for the callsign.
     memcpy(data.callsign, aircraft.callsign, ModeSAircraft::kCallSignMaxNumChars);
     // NOTE: Emergency Priority code currently not used.

--- a/firmware/common/comms/gdl90/gdl90_utils.hh
+++ b/firmware/common/comms/gdl90/gdl90_utils.hh
@@ -70,7 +70,7 @@ class GDL90Reporter {
         uint32_t participant_address;         // 24 bit ICAO address.
         float latitude_deg = 0.0f;
         float longitude_deg = 0.0f;
-        int16_t altitude_ft;
+        int32_t altitude_ft;
         uint8_t misc_indicators;
         uint8_t navigation_integrity_category = 0;      // Navigation Integrity Category (NIC).
         uint8_t navigation_accuracy_category_position;  // Navigation Accuracy Category for Postion (NACp).
@@ -116,7 +116,7 @@ class GDL90Reporter {
      * @retval Number of Bytes written to to_buf.
      */
     uint16_t WriteGDL90HeartbeatMessage(uint8_t* to_buf, uint16_t to_buf_num_bytes, uint32_t timestamp_sec_since_0000z,
-                                        uint16_t message_counts);
+                                        uint16_t modeS_message_counts, uint16_t uat_message_counts);
 
     /**
      * Write a GDL90 Initialization message.


### PR DESCRIPTION
GDL fixes for traffic and heartbeat messages since repo reorganization.

When calling WriteGDL90HeartbeatMessage from adsbee_server.cpp or comms_reporting.cpp is aircraft_dictionary.metrics.valid_uat_uplink_frames the correct metric we want to pass, I think it is.