### PR TITLE
Add surface position decode gating during invalid reference position

### DIFF
--- a/firmware/adsbee_1090/pico/host_test/test_aircraft_dictionary_mode_s.cc
+++ b/firmware/adsbee_1090/pico/host_test/test_aircraft_dictionary_mode_s.cc
@@ -1093,6 +1093,49 @@ TEST(AircraftDictionary, IngestSurfacePositionMessagesOnGround) {
     EXPECT_NEAR(aircraft_ptr->longitude_deg, WrapCPRDecodeLongitude(4.734735f - 180.0f), 0.001f);
 }
 
+TEST(AircraftDictionary, SurfacePositionSkippedWithoutReference) {
+    // Without a valid reference position, surface CPR would resolve its 90x90 degree ambiguity against the
+    // default (0, 0) reference and silently produce a wrong position. Verify that the position decode is
+    // skipped until a reference is set, while the rest of the message (air/ground state) still applies.
+    AircraftDictionary::AircraftDictionaryConfig config;
+    AircraftDictionary dictionary(config);
+    // NOTE: No SetReferencePosition call — the dictionary starts with no valid reference.
+    DecodedModeSPacket packet_0 = DecodedModeSPacket((char*)"8C4841753AAB238733C8CD4020B1");
+    DecodedModeSPacket packet_1 = DecodedModeSPacket((char*)"8C4841753A8A35323FAEBDAC702D");
+    packet_0.raw.mlat_48mhz_64bit_counts = 50123;
+    packet_1.raw.mlat_48mhz_64bit_counts = 100000;
+
+    uint32_t uid = Aircraft::ICAOToUID(0x484175, Aircraft::AircraftType::kAircraftTypeModeS);
+
+    // Both packets ingest successfully (not an error), but no position is decoded.
+    EXPECT_FALSE(dictionary.ReferencePositionValid());
+    EXPECT_TRUE(dictionary.IngestDecodedModeSPacket(packet_0));
+    EXPECT_TRUE(dictionary.IngestDecodedModeSPacket(packet_1));
+    ModeSAircraft* aircraft_ptr = dictionary.GetAircraftPtr<ModeSAircraft>(uid, false);
+    ASSERT_TRUE(aircraft_ptr);
+    EXPECT_FALSE(aircraft_ptr->HasBitFlag(ModeSAircraft::BitFlag::kBitFlagPositionValid));
+    EXPECT_FALSE(aircraft_ptr->HasBitFlag(ModeSAircraft::BitFlag::kBitFlagIsAirborne));  // Air/ground still applied.
+
+    // Once a reference appears, re-ingesting decodes the position (CPR frames were cached).
+    dictionary.SetReferencePosition(51.990f, 4.375f);
+    EXPECT_TRUE(dictionary.ReferencePositionValid());
+    packet_0.raw.mlat_48mhz_64bit_counts += 100e3;
+    packet_1.raw.mlat_48mhz_64bit_counts += 100e3;
+    EXPECT_TRUE(dictionary.IngestDecodedModeSPacket(packet_0));
+    EXPECT_TRUE(dictionary.IngestDecodedModeSPacket(packet_1));
+    EXPECT_TRUE(aircraft_ptr->HasBitFlag(ModeSAircraft::BitFlag::kBitFlagPositionValid));
+    EXPECT_NEAR(aircraft_ptr->latitude_deg, 52.320607f, 0.001f);
+    EXPECT_NEAR(aircraft_ptr->longitude_deg, 4.734735f, 0.001f);
+
+    // Clearing the reference pauses surface position decoding again (existing position stays latched).
+    dictionary.ClearReferencePosition();
+    EXPECT_FALSE(dictionary.ReferencePositionValid());
+    packet_0.raw.mlat_48mhz_64bit_counts += 100e3;
+    packet_1.raw.mlat_48mhz_64bit_counts += 100e3;
+    EXPECT_TRUE(dictionary.IngestDecodedModeSPacket(packet_0));
+    EXPECT_TRUE(dictionary.IngestDecodedModeSPacket(packet_1));
+}
+
 TEST(AircraftDictionary, IngestSurfacePositionMovementAndTrack) {
     AircraftDictionary::AircraftDictionaryConfig config;
     AircraftDictionary dictionary(config);

--- a/firmware/common/adsb/aircraft_dictionary.cpp
+++ b/firmware/common/adsb/aircraft_dictionary.cpp
@@ -278,7 +278,8 @@ bool ModeSAircraft::ApplyAircraftIDMessage(const ModeSADSBPacket& packet) {
 }
 
 bool ModeSAircraft::ApplySurfacePositionMessage(const ModeSADSBPacket& packet, uint32_t ref_lat_awb32,
-                                                uint32_t ref_lon_awb32, bool filter_cpr_position) {
+                                                uint32_t ref_lon_awb32, bool filter_cpr_position,
+                                                bool ref_position_valid) {
     WriteBitFlag(ModeSAircraft::BitFlag::kBitFlagIsAirborne, false);
 
     if (NICBitIsValid(ADSBTypes::kNICBitA) && NICBitIsValid(ADSBTypes::kNICBitC)) {
@@ -412,6 +413,12 @@ bool ModeSAircraft::ApplySurfacePositionMessage(const ModeSADSBPacket& packet, u
                  packet.raw.GetTimestampMs());
     if (!CanDecodePosition()) {
         // Can't decode aircraft position, but this is not an error.
+        return true;
+    }
+    if (!ref_position_valid) {
+        // No valid reference position: surface CPR would resolve against a bogus reference and silently produce a
+        // wrong position. Skip the position decode (the CPR frames above are cached for when a reference appears);
+        // everything else in the message has been applied, so this is not an error.
         return true;
     }
     if (DecodeSurfacePosition(ref_lat_awb32, ref_lon_awb32, filter_cpr_position)) {
@@ -1748,8 +1755,10 @@ bool AircraftDictionary::IngestModeSADSBPacket(const ModeSADSBPacket& packet) {
         case ModeSADSBPacket::kTypeCodeSurfacePosition + 1:  // TC = 6 (Surface Position)
         case ModeSADSBPacket::kTypeCodeSurfacePosition + 2:  // TC = 7 (Surface Position)
         case ModeSADSBPacket::kTypeCodeSurfacePosition + 3:  // TC = 8 (Surface Position)
-            ret = aircraft_ptr->ApplySurfacePositionMessage(
-                packet, reference_latitude_awb32_, reference_longitude_awb32_, config_.enable_cpr_position_filter);
+            ret = aircraft_ptr->ApplySurfacePositionMessage(packet, reference_latitude_awb32_,
+                                                            reference_longitude_awb32_,
+                                                            config_.enable_cpr_position_filter,
+                                                            reference_position_valid_);
             break;
         case ModeSADSBPacket::kTypeCodeAirbornePositionBaroAlt:      // TC = 9 (Airborne Position w/ Baro Altitude)
         case ModeSADSBPacket::kTypeCodeAirbornePositionBaroAlt + 1:  // TC = 10 (Airborne Position w/ Baro Altitude)
@@ -1900,6 +1909,7 @@ bool AircraftDictionary::RemoveOldestAircraft() {
 }
 
 void AircraftDictionary::SetReferencePosition(float latitude_deg, float longitude_deg) {
+    reference_position_valid_ = true;
     reference_latitude_awb32_ = lat2awb(latitude_deg);
     // Remap longitudes from (-180,180) to (0, 360)
     if (longitude_deg < 0.0f) {

--- a/firmware/common/adsb/aircraft_dictionary.hh
+++ b/firmware/common/adsb/aircraft_dictionary.hh
@@ -379,8 +379,12 @@ class ModeSAircraft : public Aircraft {
      */
 
     bool ApplyAircraftIDMessage(const ModeSADSBPacket& packet);
+    // ref_position_valid gates only the CPR position decode: surface CPR resolves its 90x90 degree ambiguity by
+    // picking the solution nearest the reference position, so decoding against an unset reference (0, 0) would
+    // silently produce a wrong position. With ref_position_valid false the rest of the message (air/ground state,
+    // movement, heading, CPR frame caching) still applies and the message is treated as successfully ingested.
     bool ApplySurfacePositionMessage(const ModeSADSBPacket& packet, uint32_t ref_lat_awb32, uint32_t ref_lon_awb32,
-                                     bool filter_cpr_position = true);
+                                     bool filter_cpr_position = true, bool ref_position_valid = true);
     bool ApplyAirbornePositionMessage(const ModeSADSBPacket& packet, bool filter_cpr_position = true);
     bool ApplyAirborneVelocitiesMessage(const ModeSADSBPacket& packet);
     bool ApplyAircraftStatusMessage(const ModeSADSBPacket& packet);
@@ -1011,6 +1015,19 @@ class AircraftDictionary {
     void SetReferencePosition(float latitude_deg, float longitude_deg);
 
     /**
+     * Marks the reference position as unavailable. While the reference is invalid, Mode S surface position packets
+     * are ingested (air/ground state, movement, heading) but their CPR position decode is skipped, since surface
+     * CPR decoded against a bogus reference silently yields a wrong position.
+     */
+    inline void ClearReferencePosition() { reference_position_valid_ = false; }
+
+    /**
+     * Check whether a valid reference position has been set.
+     * @retval True if SetReferencePosition has been called and not subsequently cleared.
+     */
+    inline bool ReferencePositionValid() const { return reference_position_valid_; }
+
+    /**
      * Check if the CPR position filter is enabled.
      * @retval True if the filter is enabled, false if it is disabled.
      */
@@ -1125,6 +1142,7 @@ class AircraftDictionary {
     // Reference position for decoding Mode S surface position packets, in angular weighted binary format.
     uint32_t reference_latitude_awb32_ = 0;
     uint32_t reference_longitude_awb32_ = 0;
+    bool reference_position_valid_ = false;  // Set by SetReferencePosition, cleared by ClearReferencePosition.
 
     FixedPoolResource pool_;  // Free-list pool + monotonic bucket region; must outlive dict.
 };


### PR DESCRIPTION
Previously it was possible to decode invalid surface positions if a position reference was not established yet. This fixes that!