### PR TITLE
Add GDL90_NO_UAT_UPLINK reporting protocol and high rate optimization

### DIFF
--- a/firmware/common/comms/comms_reporting.cpp
+++ b/firmware/common/comms/comms_reporting.cpp
@@ -58,11 +58,12 @@ bool CommsManager::UpdateReporting(const ReportSink* sinks, const SettingsManage
     ReportSink mavlink1_sinks[SettingsManager::kNumSerialInterfaces];
     ReportSink mavlink2_sinks[SettingsManager::kNumSerialInterfaces];
     ReportSink gdl90_sinks[SettingsManager::kNumSerialInterfaces];
+    ReportSink gdl90_no_uat_uplink_sinks[SettingsManager::kNumSerialInterfaces];
     ReportSink aircraftjson_sinks[SettingsManager::kNumSerialInterfaces];
 
     uint16_t num_raw_sinks = 0, num_beast_sinks = 0, num_beast_no_uat_sinks = 0, num_beast_no_uat_uplink_sinks = 0,
              num_csbee_sinks = 0, num_mavlink1_sinks = 0, num_mavlink2_sinks = 0, num_gdl90_sinks = 0,
-             num_aircraftjson_sinks = 0;
+             num_gdl90_no_uat_uplink_sinks = 0, num_aircraftjson_sinks = 0;
 
     for (uint16_t i = 0; i < num_sinks; i++) {
         switch (sink_protocols[i]) {
@@ -92,6 +93,9 @@ bool CommsManager::UpdateReporting(const ReportSink* sinks, const SettingsManage
             case SettingsManager::kGDL90:
                 gdl90_sinks[num_gdl90_sinks++] = sinks[i];
                 break;
+            case SettingsManager::kGDL90NoUATUplink:
+                gdl90_no_uat_uplink_sinks[num_gdl90_no_uat_uplink_sinks++] = sinks[i];
+                break;
             case SettingsManager::kAircraftJSON:
                 aircraftjson_sinks[num_aircraftjson_sinks++] = sinks[i];
                 break;
@@ -102,6 +106,17 @@ bool CommsManager::UpdateReporting(const ReportSink* sinks, const SettingsManage
                               SettingsManager::kReportingProtocolStrs[sink_protocols[i]]);
                 break;  // Not a periodic report protocol.
         }
+    }
+
+    // Both GDL90 variants emit identical heartbeat/ownship/traffic reports and share one reporting
+    // round; kGDL90NoUATUplink differs only in being excluded from the uplink pass-through below.
+    ReportSink gdl90_all_sinks[SettingsManager::kNumSerialInterfaces];
+    uint16_t num_gdl90_all_sinks = 0;
+    for (uint16_t i = 0; i < num_gdl90_sinks; i++) {
+        gdl90_all_sinks[num_gdl90_all_sinks++] = gdl90_sinks[i];
+    }
+    for (uint16_t i = 0; i < num_gdl90_no_uat_uplink_sinks; i++) {
+        gdl90_all_sinks[num_gdl90_all_sinks++] = gdl90_no_uat_uplink_sinks[i];
     }
 
     /**  Report Raw Packets **/
@@ -143,13 +158,13 @@ bool CommsManager::UpdateReporting(const ReportSink* sinks, const SettingsManage
     if (csbee_round_active_ && num_csbee_sinks == 0) csbee_round_active_ = false;
     if (mavlink1_round_active_ && num_mavlink1_sinks == 0) mavlink1_round_active_ = false;
     if (mavlink2_round_active_ && num_mavlink2_sinks == 0) mavlink2_round_active_ = false;
-    if (gdl90_round_active_ && num_gdl90_sinks == 0) gdl90_round_active_ = false;
+    if (gdl90_round_active_ && num_gdl90_all_sinks == 0) gdl90_round_active_ = false;
     if (aircraftjson_round_active_ && num_aircraftjson_sinks == 0) aircraftjson_round_active_ = false;
 
     bool all_locally_decoded_done = !csbee_round_active_ && !mavlink1_round_active_ && !mavlink2_round_active_ &&
                                     !gdl90_round_active_ && !aircraftjson_round_active_;
     bool any_locally_decoded_active = (num_csbee_sinks > 0 || num_mavlink1_sinks > 0 || num_mavlink2_sinks > 0 ||
-                                       num_gdl90_sinks > 0 || num_aircraftjson_sinks > 0);
+                                       num_gdl90_all_sinks > 0 || num_aircraftjson_sinks > 0);
 
     if (any_locally_decoded_active && all_locally_decoded_done &&
         timestamp_ms - last_locally_decoded_report_timestamp_ms_ >= kCSBeeReportingIntervalMs) {
@@ -177,7 +192,7 @@ bool CommsManager::UpdateReporting(const ReportSink* sinks, const SettingsManage
         csbee_round_active_ = (num_csbee_sinks > 0);
         mavlink1_round_active_ = (num_mavlink1_sinks > 0);
         mavlink2_round_active_ = (num_mavlink2_sinks > 0);
-        gdl90_round_active_ = (num_gdl90_sinks > 0);
+        gdl90_round_active_ = (num_gdl90_all_sinks > 0);
         aircraftjson_round_active_ = (num_aircraftjson_sinks > 0);
     }
 
@@ -222,7 +237,7 @@ bool CommsManager::UpdateReporting(const ReportSink* sinks, const SettingsManage
                           kGDL90ReportingIntervalMs);
             gdl90_overrun_reported_ = true;
         }
-        if (!ReportGDL90(gdl90_sinks, num_gdl90_sinks)) {
+        if (!ReportGDL90(gdl90_all_sinks, num_gdl90_all_sinks)) {
             CONSOLE_ERROR("CommsManager::UpdateReporting", "Error during ReportGDL90.");
             ret = false;
         }

--- a/firmware/common/comms/comms_reporting.cpp
+++ b/firmware/common/comms/comms_reporting.cpp
@@ -49,17 +49,25 @@ bool CommsManager::UpdateReporting(const ReportSink* sinks, const SettingsManage
     bool ret = true;
     uint32_t timestamp_ms = get_time_since_boot_ms();
 
+    // Every sink lands in exactly one per-protocol array below, so each array must be able to hold all
+    // sinks a caller can legally pass (serial interfaces on the Pico, IP feeds on the ESP32).
+    if (num_sinks > SettingsManager::kMaxNumReportSinks) {
+        CONSOLE_ERROR("CommsManager::UpdateReporting", "Called with %u sinks but arrays are sized for %u; clamping.",
+                      num_sinks, SettingsManager::kMaxNumReportSinks);
+        num_sinks = SettingsManager::kMaxNumReportSinks;
+    }
+
     // Build lists of sinks for each reporting protocol.
-    ReportSink raw_sinks[SettingsManager::kNumSerialInterfaces];
-    ReportSink beast_sinks[SettingsManager::kNumSerialInterfaces];
-    ReportSink beast_no_uat_sinks[SettingsManager::kNumSerialInterfaces];
-    ReportSink beast_no_uat_uplink_sinks[SettingsManager::kNumSerialInterfaces];
-    ReportSink csbee_sinks[SettingsManager::kNumSerialInterfaces];
-    ReportSink mavlink1_sinks[SettingsManager::kNumSerialInterfaces];
-    ReportSink mavlink2_sinks[SettingsManager::kNumSerialInterfaces];
-    ReportSink gdl90_sinks[SettingsManager::kNumSerialInterfaces];
-    ReportSink gdl90_no_uat_uplink_sinks[SettingsManager::kNumSerialInterfaces];
-    ReportSink aircraftjson_sinks[SettingsManager::kNumSerialInterfaces];
+    ReportSink raw_sinks[SettingsManager::kMaxNumReportSinks];
+    ReportSink beast_sinks[SettingsManager::kMaxNumReportSinks];
+    ReportSink beast_no_uat_sinks[SettingsManager::kMaxNumReportSinks];
+    ReportSink beast_no_uat_uplink_sinks[SettingsManager::kMaxNumReportSinks];
+    ReportSink csbee_sinks[SettingsManager::kMaxNumReportSinks];
+    ReportSink mavlink1_sinks[SettingsManager::kMaxNumReportSinks];
+    ReportSink mavlink2_sinks[SettingsManager::kMaxNumReportSinks];
+    ReportSink gdl90_sinks[SettingsManager::kMaxNumReportSinks];
+    ReportSink gdl90_no_uat_uplink_sinks[SettingsManager::kMaxNumReportSinks];
+    ReportSink aircraftjson_sinks[SettingsManager::kMaxNumReportSinks];
 
     uint16_t num_raw_sinks = 0, num_beast_sinks = 0, num_beast_no_uat_sinks = 0, num_beast_no_uat_uplink_sinks = 0,
              num_csbee_sinks = 0, num_mavlink1_sinks = 0, num_mavlink2_sinks = 0, num_gdl90_sinks = 0,
@@ -110,7 +118,7 @@ bool CommsManager::UpdateReporting(const ReportSink* sinks, const SettingsManage
 
     // Both GDL90 variants emit identical heartbeat/ownship/traffic reports and share one reporting
     // round; kGDL90NoUATUplink differs only in being excluded from the uplink pass-through below.
-    ReportSink gdl90_all_sinks[SettingsManager::kNumSerialInterfaces];
+    ReportSink gdl90_all_sinks[SettingsManager::kMaxNumReportSinks];
     uint16_t num_gdl90_all_sinks = 0;
     for (uint16_t i = 0; i < num_gdl90_sinks; i++) {
         gdl90_all_sinks[num_gdl90_all_sinks++] = gdl90_sinks[i];

--- a/firmware/common/coprocessor/composite_array.cpp
+++ b/firmware/common/coprocessor/composite_array.cpp
@@ -22,13 +22,19 @@ CompositeArray::RawPackets CompositeArray::PackRawPacketsBuffer(uint8_t* buf, ui
 
     // Reserve room for a couple of uplink packets up front: Mode S and UAT ADS-B pack first, and under
     // sustained traffic they would otherwise fill every batch and starve the low-rate uplink queue forever.
+    // Never reserve more than the buffer could actually hold past the header, so a buffer too small for
+    // any uplink still packs Mode S / UAT ADS-B instead of holding space no uplink can use.
     constexpr uint16_t kMaxReservedUplinkPackets = 2;
     uint16_t reserved_uplink_bytes = 0;
     if (uat_uplink_queue) {
+        uint16_t max_uplinks_that_fit =
+            buf_len_bytes > sizeof(RawPackets::Header)
+                ? (buf_len_bytes - sizeof(RawPackets::Header)) / sizeof(RawUATUplinkPacket)
+                : 0;
         uint16_t num_uplinks = uat_uplink_queue->Length();
-        reserved_uplink_bytes =
-            (num_uplinks < kMaxReservedUplinkPackets ? num_uplinks : kMaxReservedUplinkPackets) *
-            sizeof(RawUATUplinkPacket);
+        if (num_uplinks > kMaxReservedUplinkPackets) num_uplinks = kMaxReservedUplinkPackets;
+        if (num_uplinks > max_uplinks_that_fit) num_uplinks = max_uplinks_that_fit;
+        reserved_uplink_bytes = num_uplinks * sizeof(RawUATUplinkPacket);
     }
 
     // Fill up the CompositeArray::RawPackets header and associated buffers with as many packets as we can report.

--- a/firmware/common/coprocessor/composite_array.cpp
+++ b/firmware/common/coprocessor/composite_array.cpp
@@ -20,12 +20,23 @@ CompositeArray::RawPackets CompositeArray::PackRawPacketsBuffer(uint8_t* buf, ui
     packets_to_report.header->num_uat_adsb_packets = 0;
     packets_to_report.header->num_uat_uplink_packets = 0;
 
+    // Reserve room for a couple of uplink packets up front: Mode S and UAT ADS-B pack first, and under
+    // sustained traffic they would otherwise fill every batch and starve the low-rate uplink queue forever.
+    constexpr uint16_t kMaxReservedUplinkPackets = 2;
+    uint16_t reserved_uplink_bytes = 0;
+    if (uat_uplink_queue) {
+        uint16_t num_uplinks = uat_uplink_queue->Length();
+        reserved_uplink_bytes =
+            (num_uplinks < kMaxReservedUplinkPackets ? num_uplinks : kMaxReservedUplinkPackets) *
+            sizeof(RawUATUplinkPacket);
+    }
+
     // Fill up the CompositeArray::RawPackets header and associated buffers with as many packets as we can report.
     if (mode_s_queue) {
         // Stuff with Mode S packets.
         RawModeSPacket mode_s_packet;
         packets_to_report.mode_s_packets = reinterpret_cast<RawModeSPacket*>(buf + packets_to_report.len_bytes);
-        while (packets_to_report.len_bytes + sizeof(RawModeSPacket) <= buf_len_bytes &&
+        while (packets_to_report.len_bytes + sizeof(RawModeSPacket) + reserved_uplink_bytes <= buf_len_bytes &&
                mode_s_queue->Dequeue(mode_s_packet)) {
             memcpy(&packets_to_report.mode_s_packets[packets_to_report.header->num_mode_s_packets], &mode_s_packet,
                    sizeof(RawModeSPacket));
@@ -37,7 +48,7 @@ CompositeArray::RawPackets CompositeArray::PackRawPacketsBuffer(uint8_t* buf, ui
         // Stuff with UAT ADS-B packets.
         RawUATADSBPacket uat_adsb_packet;
         packets_to_report.uat_adsb_packets = reinterpret_cast<RawUATADSBPacket*>(buf + packets_to_report.len_bytes);
-        while (packets_to_report.len_bytes + sizeof(RawUATADSBPacket) <= buf_len_bytes &&
+        while (packets_to_report.len_bytes + sizeof(RawUATADSBPacket) + reserved_uplink_bytes <= buf_len_bytes &&
                uat_adsb_queue->Dequeue(uat_adsb_packet)) {
             memcpy(&packets_to_report.uat_adsb_packets[packets_to_report.header->num_uat_adsb_packets],
                    &uat_adsb_packet, sizeof(RawUATADSBPacket));

--- a/firmware/common/settings/settings.hh
+++ b/firmware/common/settings/settings.hh
@@ -271,6 +271,12 @@ class SettingsManager {
         }
     };
 
+    // Maximum number of sinks that can be passed to CommsManager::UpdateReporting() in a single call:
+    // serial interfaces on the Pico, IP feeds on the ESP32. Per-protocol sink arrays are sized with this.
+    static constexpr uint16_t kMaxNumReportSinks = Settings::kMaxNumFeeds > SerialInterface::kNumSerialInterfaces
+                                                       ? Settings::kMaxNumFeeds
+                                                       : SerialInterface::kNumSerialInterfaces;
+
     // This struct contains device information that should persist across firmware upgrades.
     struct DeviceInfo {
         // NOTE: Lengths do not include null terminator.

--- a/firmware/common/settings/settings.hh
+++ b/firmware/common/settings/settings.hh
@@ -41,6 +41,7 @@ class SettingsManager {
         kMAVLINK2,
         kGDL90,
         kAircraftJSON,
+        kGDL90NoUATUplink,  // Appended (not next to kGDL90): values are flash-persisted, don't renumber.
         kNumProtocols
     };
     static constexpr uint16_t kReportingProtocolStrMaxLen = 30;

--- a/firmware/common/settings/settings_strs.cpp
+++ b/firmware/common/settings/settings_strs.cpp
@@ -12,7 +12,8 @@ const char
     SettingsManager::kReportingProtocolStrs[SettingsManager::ReportingProtocol::kNumProtocols]
                                            [SettingsManager::kReportingProtocolStrMaxLen] = {
                                                "NONE",  "RAW",      "BEAST",    "BEAST_NO_UAT", "BEAST_NO_UAT_UPLINK",
-                                               "CSBEE", "MAVLINK1", "MAVLINK2", "GDL90", "AIRCRAFT_JSON"};
+                                               "CSBEE", "MAVLINK1", "MAVLINK2", "GDL90", "AIRCRAFT_JSON",
+                                               "GDL90_NO_UAT_UPLINK"};
 
 const char SettingsManager::kSubGHzModeStrs[SettingsManager::kNumSubGHzRadioModes]
                                            [SettingsManager::kSubGHzModeStrMaxLen] = {


### PR DESCRIPTION
Add GDL90_NO_UAT_UPLINK reporting protocol, cange composite array reporting queue behavior so that at least 2x uplink packets get packed in before traffic packets in case they are pending